### PR TITLE
Fix TypeError when using SVGs as title

### DIFF
--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -351,7 +351,7 @@ var Tabs = function (_React$Component) {
         return;
       }
 
-      var classes = e.target.className.split(' ');
+      var classes = (e.target.getAttribute('class') || '').split(' ');
       if (classes.indexOf('rdTabCloseIcon') > -1) {
         this._cancelEventSafety(e);
       } else {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -259,7 +259,7 @@ class Tabs extends React.Component {
       return;
     }
 
-    const classes = e.target.className.split(' ');
+    const classes = (e.target.getAttribute('class') || '').split(' ');
     if (classes.indexOf('rdTabCloseIcon') > -1) {
       this._cancelEventSafety(e);
     } else {


### PR DESCRIPTION

First of all thanks for this awesome component!

### Issue

Using SVG icons as `title` attibutes can result in the following Error:

    Tabs.js:354 Uncaught TypeError: e.target.className.split is not a function

### Solution

This is because the getter `someSVGNode.className` retuns an Object instead of a string.
To bypass this issue we should use `someSVGNode.getAttribute('class')` instead of `someSVGNode.className`.

### Example to Reproduce

    ...
    <Tab
      title={<SomeSVGIcon />}>
    ...