### PR TITLE
Fix tabAddButton position

### DIFF
--- a/lib/components/TabStyles.js
+++ b/lib/components/TabStyles.js
@@ -190,7 +190,7 @@ var TabStyles = {
     fontFamily: "'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
     fontSize: '20px',
     textShadow: 'rgb(255, 255, 255) 0px 1px 0px',
-    position: 'fixed',
+    position: 'relative',
     width: '25px',
     height: '26px',
     marginLeft: '20px',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-draggable-tab",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Draggable chrome like tab react component ",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/components/TabStyles.js
+++ b/src/components/TabStyles.js
@@ -185,7 +185,7 @@ const TabStyles = {
     fontFamily: "'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif",
     fontSize: '20px',
     textShadow: 'rgb(255, 255, 255) 0px 1px 0px',
-    position: 'fixed',
+    position: 'relative',
     width: '25px',
     height: '26px',
     marginLeft: '20px',


### PR DESCRIPTION
`position: fixed` caused a weird styling issue with the `+` add tab button being at the beginning...
![screenshot from 2016-08-16 19-53-44](https://cloud.githubusercontent.com/assets/13342266/17722045/4f37730a-63ec-11e6-83ba-53efd9a18f1f.png)
