### PR TITLE
Added prop to disable the dragging of tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ For React v0.13.x, please use react-draggable-tab v0.3.3.
   * `selectedTab`: key for selectedTab.
     `React.PropTypes.string` default to first tab.
 
+  * 'disableDrag': disables the ability to drag the tabs.
+    'React.PropTypes.bool' default is false.
+
   * `tabAddButton`: element for add button.
     `React.PropTypes.element`
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -478,6 +478,7 @@ class Tabs extends React.Component {
       return (
         <CustomDraggable
           key={`draggable_tabs_${tab.key}`}
+          disabled={this.props.disableDrag}
           axis="x"
           cancel=".rdTabCloseIcon"
           start={{ x: 0, y: 0 }}
@@ -547,6 +548,7 @@ Tabs.defaultProps = {
   onTabPositionChange: () => {},
   shouldTabClose: () => true,
   keepSelectedTab: false,
+  disableDrag: false,
 };
 
 Tabs.propTypes = {
@@ -603,6 +605,7 @@ Tabs.propTypes = {
   onTabPositionChange: React.PropTypes.func,
   shouldTabClose: React.PropTypes.func,
   keepSelectedTab: React.PropTypes.bool,
+  disableDrag: React.PropTypes.bool,
 };
 
 export default Tabs;

--- a/test/components/Tabs_spec.js
+++ b/test/components/Tabs_spec.js
@@ -32,6 +32,7 @@ describe('Test of Tabs', () => {
     expect(component.props.tabsClassNames.tabCloseIcon).to.be.equal('');
     expect(component.props.tabsClassNames.tabActive).to.be.equal('');
     expect(component.props.tabsClassNames.tabHover).to.be.equal('');
+    expect(component.props.disableDrag).to.be.equal(false);
 
     expect(component.props.tabsStyles).to.be.empty;
 
@@ -1162,6 +1163,86 @@ describe('Test of Tabs', () => {
       expect(currentTabs[1].key).to.be.equal('tab1');
       expect(currentTabs[2].key).to.be.equal('tab2');
       expect(currentTabs[3].key).to.be.equal('tab4');
+    });
+  })
+
+  describe('when disabled and attempts to drag', function () {
+    let called = false;
+
+    let target1;
+    let target2;
+
+    const tabs = [
+      (<Tab key={'tab1'} title={'tab1'}>
+        <div>
+          <h1>tab1Content</h1>
+        </div>
+      </Tab>),
+      (<Tab key={'tab2'} title={'tab2'}>
+        <div>
+          <h1>tab2Content</h1>
+        </div>
+      </Tab>),
+      (<Tab key={'tab3'} title={'tab3'}>
+        <div>
+          <h1>tab3Content</h1>
+        </div>
+      </Tab>),
+      (<Tab key={'tab4'} title={'tab4'}>
+        <div>
+          <h1>tab4Content</h1>
+        </div>
+      </Tab>)
+
+    ];
+
+    beforeEach(() => {
+      ReactDom.render(
+        <Tabs
+          tabsClassNames={{tabCloseIcon: 'myCloseButton'}}
+          onTabPositionChange={function (e, _key, _currentTabs) {
+            called = true;
+          }}
+          selectedTab="tab1"
+          tabs={tabs}
+        disableDrag={true}/>, document.body);
+    });
+
+    afterEach(() => {
+      ReactDom.unmountComponentAtNode(document.body);
+      target1 = null;
+      target2 = null;
+      called = false;
+    });
+
+    it('attemp to switch position when dragging is disabled', () => {
+
+      target1 = document.getElementsByClassName('rdTab')[0];
+      target2 = document.getElementsByClassName('rdTab')[1];
+
+      let clientY = target1.getBoundingClientRect().top + 5;
+      let droppedToX = target2.getBoundingClientRect().left + 10;
+
+      triggerEvent(target1, 'mousedown', {
+        clientX: target1.getBoundingClientRect().left + 5,
+        clientY: clientY,
+        offset: {
+          left: target1.getBoundingClientRect().left + 10,
+          top: target1.getBoundingClientRect().top + 10
+        }
+      });
+
+      triggerEvent(target1, 'mousemove', {
+        clientX: target2.getBoundingClientRect().left + 10,
+        clientY: clientY
+      });
+
+      triggerEvent(target1, 'mouseup', {
+        clientX: droppedToX,
+        clientY: clientY
+      });
+
+      expect(called).to.be.equal(false);
     });
   });
 


### PR DESCRIPTION
Since your tab UI is better than most of the ones I saw online for my needs, I added a property to allow me to disable the dragging, as its behavior is buggy.